### PR TITLE
Runtime toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ The buildpack will do the following for Node.js applications:
 * Contributes the Datadog Node.js trace agent to a layer
 * Require the trace agent, if it's not present
 
+
+## Configuration
+| Environment Variable | Description
+| -------------------- | -----------
+| `$BP_DATADOG_ENABLED` | Whether to contribute JProfiler support
+| `$BPL_DATADOG_ENABLED` | Whether to enable JProfiler support
+
 ## Usage
 
 Instructions for using the buildpack can be found at the links below:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The buildpack will do the following for Node.js applications:
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
-| `$BP_DATADOG_ENABLED` | Whether to contribute JProfiler support
-| `$BPL_DATADOG_ENABLED` | Whether to enable JProfiler support
+| `$BP_DATADOG_ENABLED` | whether to contribute the Datadog trace agent
+| `$BPL_DATADOG_DISABLED` | whether to disable the Datadog trace agent (Java only!)
 
 ## Usage
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,14 +32,16 @@ api = "0.7"
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]
-    description = "whether to enable Datadog support"
-    launch = true
-    name = "BPL_DATADOG_ENABLED"
+    build = true
+    default = "false"
+    description = "whether to contribute the Datadog trace agent"
+    name = "BP_DATADOG_ENABLED"
 
   [[metadata.configurations]]
-    build = false
-    description = "whether to contribute Datadog support"
-    name = "BP_DATADOG_ENABLED"
+    launch = true
+    default = "false"
+    description = "whether to disable the Datadog trace agent (Java only!)"
+    name = "BPL_DATADOG_DISABLED"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:datadoghq:java-agent:1.6.0:*:*:*:*:*:*:*"]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,13 +28,17 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/maven/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]
-    build = true
-    default = "false"
-    description = "enable the Datadog Java Trace Agent"
+    description = "whether to enable Datadog support"
+    launch = true
+    name = "BPL_DATADOG_ENABLED"
+
+  [[metadata.configurations]]
+    build = false
+    description = "whether to contribute Datadog support"
     name = "BP_DATADOG_ENABLED"
 
   [[metadata.dependencies]]

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/paketo-buildpacks/datadog/helper"
+	"github.com/paketo-buildpacks/libpak/sherpa"
+)
+
+func main() {
+	sherpa.Execute(func() error {
+		return sherpa.Helpers(map[string]sherpa.ExecD{
+			"toggle": helper.Toggle{},
+		})
+	})
+}

--- a/datadog/build.go
+++ b/datadog/build.go
@@ -45,6 +45,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 
 		result.Layers = append(result.Layers, NewJavaAgent(agentDependency, dc, b.Logger))
+
+		h, be := libpak.NewHelperLayer(context.Buildpack, "datadogToggle")
+		h.Logger = b.Logger
+		result.Layers = append(result.Layers, h)
+		result.BOM.Entries = append(result.BOM.Entries, be)
 	}
 
 	if _, ok, err := pr.Resolve("datadog-nodejs"); err != nil {

--- a/datadog/build_test.go
+++ b/datadog/build_test.go
@@ -41,8 +41,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(1))
+		Expect(result.Layers).To(HaveLen(2))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-java"))
+		Expect(result.Layers[1].Name()).To(Equal("helper"))
 	})
 
 	it("contributes Java agent API >= 0.7", func() {
@@ -64,8 +65,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := datadog.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(1))
+		Expect(result.Layers).To(HaveLen(2))
 		Expect(result.Layers[0].Name()).To(Equal("datadog-agent-java"))
+		Expect(result.Layers[1].Name()).To(Equal("helper"))
 	})
 
 	it("contributes NodeJS agent API <= 0.6", func() {

--- a/datadog/java_agent.go
+++ b/datadog/java_agent.go
@@ -41,6 +41,7 @@ func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to copy artifact to %s\n%w", file, err)
 		}
 		layer.LaunchEnvironment.Default("BPI_DATADOG_AGENT_PATH", file)
+		layer.LaunchEnvironment.Appendf("JAVA_TOOL_OPTIONS", " ", "-javaagent:%s", file)
 		return layer, nil
 	})
 }

--- a/datadog/java_agent.go
+++ b/datadog/java_agent.go
@@ -40,9 +40,7 @@ func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		if err := sherpa.CopyFile(artifact, file); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to copy artifact to %s\n%w", file, err)
 		}
-
-		layer.LaunchEnvironment.Appendf("JAVA_TOOL_OPTIONS", " ", "-javaagent:%s", file)
-
+		layer.LaunchEnvironment.Default("BPI_DATADOG_AGENT_PATH", file)
 		return layer, nil
 	})
 }

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -1,0 +1,14 @@
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnit(t *testing.T) {
+	suite := spec.New("helper", spec.Report(report.Terminal{}))
+	suite("Properties", testToggle)
+	suite.Run(t)
+}

--- a/helper/toggle.go
+++ b/helper/toggle.go
@@ -1,0 +1,52 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/heroku/color"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/sherpa"
+)
+
+type Toggle struct {
+	Logger bard.Logger
+}
+
+func (t Toggle) Execute() (map[string]string, error) {
+	t.Logger.Infof(color.CyanString("Datadog toggle process start..."))
+	if datadogDisabled(t) {
+		t.Logger.Infof(color.CyanString("Datadog agent disabled by property t_ENABLED"))
+		return nil, nil
+	}
+
+	p, ok := os.LookupEnv("BPI_DATADOG_AGENT_PATH")
+	if !ok {
+		t.Logger.Infof(color.RedString("$BPI_DATADOG_AGENT_PATH is not set during build."))
+		return nil, fmt.Errorf("$BPI_DATADOG_AGENT_PATH must be set")
+	}
+	t.Logger.Infof(color.GreenString("Datadog agent path: %s", p))
+
+	var values []string
+	if s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS"); ok {
+		values = append(values, s)
+	}
+	values = append(values, fmt.Sprintf("-javaagent:%s", p))
+	java_tool_options := strings.Join(values, " ")
+	//t.Logger.Infof(color.GreenString("[Datadog toggle] JAVA_TOOL_OPTIONS: %s", java_tool_options))
+
+	return map[string]string{"JAVA_TOOL_OPTIONS": java_tool_options}, nil
+}
+
+func datadogDisabled(t Toggle) bool {
+	val := sherpa.GetEnvWithDefault("BPL_DATADOG_ENABLED", "true")
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		// enable by default, but warn if we couldn't understand something
+		t.Logger.Infof("defaulting to enabling Datadog as '%s' could not be parsed as either true or false", val)
+		return false
+	}
+	return !enabled
+}

--- a/helper/toggle_test.go
+++ b/helper/toggle_test.go
@@ -17,56 +17,56 @@ func testToggle(t *testing.T, context spec.G, it spec.S) {
 		toggle = helper.Toggle{}
 	)
 
+	it.Before(func() {
+		Expect(os.Setenv("BPL_DATADOG_DISABLED", "true")).To(Succeed())
+	})
+
+	it.After(func() {
+		Expect(os.Unsetenv("BPL_DATADOG_DISABLED")).To(Succeed())
+	})
+
 	it("returns if $BPL_DATADOG_DISABLED is not set", func() {
 		Expect(toggle.Execute()).To(BeNil())
 	})
 
 	context("$BPL_DATADOG_DISABLED", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BPL_DATADOG_DISABLED", "")).To(Succeed())
+			Expect(os.Unsetenv("BPL_DATADOG_DISABLED")).To(Succeed())
 		})
 
 		it.After(func() {
 			Expect(os.Unsetenv("BPL_DATADOG_DISABLED")).To(Succeed())
 		})
 
-		it("returns error if $BPI_DATADOG_AGENT_PATH is not set", func() {
-			_, err := toggle.Execute()
-			Expect(err).To(MatchError("$BPI_DATADOG_AGENT_PATH must be set"))
-		})
-
-		context("$BPI_DATADOG_AGENT_PATH", func() {
+		context("$JAVA_TOOL_OPTIONS", func() {
 			it.Before(func() {
-				Expect(os.Setenv("BPI_DATADOG_AGENT_PATH", "/mock/path/to/agent")).To(Succeed())
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
 			})
 
 			it.After(func() {
-				Expect(os.Unsetenv("BPI_DATADOG_AGENT_PATH")).To(Succeed())
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
 			})
 
-			it("contributes configuration", func() {
-				Expect(toggle.Execute()).To(Equal(map[string]string{
-					"JAVA_TOOL_OPTIONS": "-javaagent:/mock/path/to/agent",
-				}))
+			it("returns error if $BPI_DATADOG_AGENT_PATH is not set", func() {
+				_, err := toggle.Execute()
+				Expect(err).To(MatchError("$BPI_DATADOG_AGENT_PATH must be set"))
 			})
 
-			context("$JAVA_TOOL_OPTIONS", func() {
+			context("$BPI_DATADOG_AGENT_PATH", func() {
 				it.Before(func() {
-					Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+					Expect(os.Setenv("BPI_DATADOG_AGENT_PATH", "/mock/path/to/agent.jar")).To(Succeed())
 				})
 
 				it.After(func() {
-					Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+					Expect(os.Unsetenv("BPI_DATADOG_AGENT_PATH")).To(Succeed())
 				})
 
-				it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS", func() {
+				it("contributes configuration", func() {
 					Expect(toggle.Execute()).To(Equal(map[string]string{
-						"JAVA_TOOL_OPTIONS": "test-java-tool-options -javaagent:/mock/path/to/agent",
+						"JAVA_TOOL_OPTIONS": "test-java-tool-options -javaagent:/mock/path/to/agent.jar",
 					}))
 				})
 			})
-
 		})
 	})
-
 }

--- a/helper/toggle_test.go
+++ b/helper/toggle_test.go
@@ -1,0 +1,72 @@
+package helper_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+
+	"github.com/paketo-buildpacks/datadog/helper"
+)
+
+func testToggle(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		toggle = helper.Toggle{}
+	)
+
+	it("returns if $BPL_DATADOG_DISABLED is not set", func() {
+		Expect(toggle.Execute()).To(BeNil())
+	})
+
+	context("$BPL_DATADOG_DISABLED", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BPL_DATADOG_DISABLED", "")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_DATADOG_DISABLED")).To(Succeed())
+		})
+
+		it("returns error if $BPI_DATADOG_AGENT_PATH is not set", func() {
+			_, err := toggle.Execute()
+			Expect(err).To(MatchError("$BPI_DATADOG_AGENT_PATH must be set"))
+		})
+
+		context("$BPI_DATADOG_AGENT_PATH", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPI_DATADOG_AGENT_PATH", "/mock/path/to/agent")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPI_DATADOG_AGENT_PATH")).To(Succeed())
+			})
+
+			it("contributes configuration", func() {
+				Expect(toggle.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-javaagent:/mock/path/to/agent",
+				}))
+			})
+
+			context("$JAVA_TOOL_OPTIONS", func() {
+				it.Before(func() {
+					Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+				})
+
+				it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS", func() {
+					Expect(toggle.Execute()).To(Equal(map[string]string{
+						"JAVA_TOOL_OPTIONS": "test-java-tool-options -javaagent:/mock/path/to/agent",
+					}))
+				})
+			})
+
+		})
+	})
+
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/datadog/cmd/helper
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/datadog/cmd/main
 
 if [ "${STRIP:-false}" != "false" ]; then


### PR DESCRIPTION
## Summary

!DO NOT MERGE--INTERNAL REVIEW ONLY!

Add a new runtime flag, $BPL_DATADOG_DISABLED, defaulting to false, that can be used to disable the datadog agent at runtime.

Resolves issue: https://github.com/paketo-buildpacks/datadog/issues/128

## Use Cases
As a developer, I want to promote a single image through my pipeline, but since my lower environments do not integrate with production monitoring tools such as Datadog and I want to be able to disable the java agent at runtime for these environments.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
